### PR TITLE
fix: 박스스코어 날짜 포맷팅 오류 해결(#142)

### DIFF
--- a/src/features/game/BoxScoreTab.tsx
+++ b/src/features/game/BoxScoreTab.tsx
@@ -5,6 +5,7 @@ import {
   MatchScoreTable,
   PitchingRecordTable,
 } from '@/features/game/components/table';
+import { formatDate } from '@/lib/utils';
 import { useParams } from 'react-router';
 import KeyRecordsCard from './components/card/KeyRecordsCard';
 import { MatchBoard } from './components/common';
@@ -63,7 +64,9 @@ const BoxscoreTab = () => {
             stadium: '홈',
             tabType: 'MatchBoard',
           }}
-          matchDate={matchData?.schedule.current.gameDate.toString()}
+          matchDate={formatDate(
+            matchData?.schedule.current.gameDate.toString()
+          )}
           matchTime={matchData?.schedule.current.gtime}
           stadium={matchData?.schedule.current.stadium}
           gameTable={<MatchScoreTable data={matchData?.scoreboard} />}

--- a/src/features/game/components/common/MatchBoard.tsx
+++ b/src/features/game/components/common/MatchBoard.tsx
@@ -27,13 +27,6 @@ const MatchBoard = ({
   disablePrev = false,
   disableNext = false,
 }: MatchBoardProps) => {
-  const formatDate = (dateStr: string) => {
-    const year = dateStr.slice(0, 4);
-    const month = dateStr.slice(4, 6);
-    const day = dateStr.slice(6, 8);
-    return `${year}년 ${parseInt(month)}월 ${parseInt(day)}일`;
-  };
-
   return (
     <div className="w-full flex flex-col items-center justify-between px-8 py-6 gap-4 bg-wiz-white bg-opacity-10 rounded overflow-hidden">
       {/* 날짜 헤더 */}
@@ -52,7 +45,7 @@ const MatchBoard = ({
         </button>
         <div className="relative flex flex-col items-center md:gap-1">
           <span className="text-lg md:text-xl lg:text-2xl font-semibold">
-            {matchDate ? formatDate(matchDate) : '정보 없음'}
+            {matchDate || '정보 없음'}
           </span>
           <span className="text-center text-wiz-white text-opacity-50 text-sm md:text-md lg:text-lg">
             {matchTime} | {stadium}


### PR DESCRIPTION
# 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
MatchBoard가 관전포인트랑 공통으로 쓰이는데, 박스스코어에서 포맷팅을 적용하지 않았었습니다. 
따라서 BoxscoreTab에서 날짜를 포맷팅했습니다.

<img width="1240" alt="Screenshot 2025-01-03 at 2 57 54 PM" src="https://github.com/user-attachments/assets/565a663f-60d8-49e7-a5b4-420afe99534e" />

<img width="1255" alt="Screenshot 2025-01-03 at 2 57 59 PM" src="https://github.com/user-attachments/assets/8c0bd757-3a50-4115-8975-4beb625e1567" />

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
