### PR TITLE
FIX/#186 캐러셀 전체 경기 보여주는 오류 해결

### DIFF
--- a/src/features/game/apis/match-schedule/matchScheduleApi.query.ts
+++ b/src/features/game/apis/match-schedule/matchScheduleApi.query.ts
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { format, addMonths, subMonths } from 'date-fns';
 import { CarouselApi } from '@/components/ui';
 import { GameSchedule } from '@/features/game/types/match-schedule';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { addMonths, format, subMonths } from 'date-fns';
+import { useEffect } from 'react';
 import { scheduleApi } from './matchScheduleApi';
 
 interface UseMatchScheduleQueryParams {
@@ -30,7 +30,7 @@ export const useGetMatchScheduleQuery = ({
 
   // 호출할 함수 선택
   const fetchFn =
-    type === 'kt'
+    type !== 'all'
       ? async (yearMonth: string): Promise<GameSchedule[]> => {
           const response = await scheduleApi.getMonthSchedule(yearMonth);
           return response.data.list;
@@ -39,6 +39,7 @@ export const useGetMatchScheduleQuery = ({
           const response = await scheduleApi.getAllMonthSchedule(yearMonth);
           return response.data.list;
         };
+
   // 현재 달 데이터 가져오기
   const {
     data: currentData = [],


### PR DESCRIPTION
# 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
 캐러셀에서는 항상 kt 경기만 보여줘야 하는데 recent일 때 전체 경기 가져오는 오류 발견 (recent = 최근 경기 일정 < 현재 날짜)
- 호출할 함수 결정 조건 변경 
- 기존: type === ‘kt’ ? getMonthSchedule : getAllMonthSchedule 호출 → type !== ‘all’로 변경했습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
